### PR TITLE
Fix The Talos Principle 2 hooking

### DIFF
--- a/AdrenalineHookWpf/Services/GmdbService.cs
+++ b/AdrenalineHookWpf/Services/GmdbService.cs
@@ -174,7 +174,7 @@ public sealed class GmdbService
                 removed++;
                 continue;
             }
-            kept.Add(n);
+            kept.Add(n?.DeepClone());
         }
 
         root["games"] = kept;

--- a/AdrenalineHookWpf/Services/UwpScanner.cs
+++ b/AdrenalineHookWpf/Services/UwpScanner.cs
@@ -227,7 +227,13 @@ public sealed class UwpScanner
                     {
                         var found = FileSearch.FindFileByName(install, exeName);
                         if (!string.IsNullOrWhiteSpace(found))
+                        {
+                            // Talos2 has 'Talos2/Binaries/WinGDK/Talos2-WinGDK-Shipping.exe' as name which then fails to match the process when running.
+                            // canonicalize to the actual file on disk to ensure it matches the process path.
+                            found = Path.GetFullPath(found);
+
                             return found;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The Talos Principle 2 has unix directory seperators in MicrosoftGame.config:

    <Executable Name="Talos2/Binaries/WinGDK/Talos2-WinGDK-Shipping.exe" Id="AppUEGameShipping" OverrideDisplayName="ms-resource:AppDisplayName" TargetDeviceFamily="PC" />

When added as is Adrenaline doesn't detect the game running because Process Path is different.

Also, Adrenaline Hook crashed with exception when tryingto unhook anything for me. Not sure how it's supposed to work but DeepCloning the node worked for me.